### PR TITLE
fixup configurableFlake call

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -14,9 +14,9 @@
     , config ? { }
     }: outputBuilder:
       let mergedConfig = evalConfig options config;
-          withConfig = newConfig: configurableFlake {
+          withConfig = newConfig: configurableFlake inputs {
             config = newConfig;
-            inherit options inputs;} outputBuilder;
+            inherit options;} outputBuilder;
       in
         (outputBuilder (inputs // {config = mergedConfig.config;})) //
         { config = mergedConfig; inherit options withConfig;};


### PR DESCRIPTION
Without this change I see the following error:

```
error: value is a function while a set was expected

       at /nix/store/lh8hgdgxp2a8fpdbjii3ygiq0hsvlijq-source/lib.nix:17:35:

           16|       let mergedConfig = evalConfig options config;
           17|           withConfig = newConfig: configurableFlake {
             |                                   ^
           18|             config = newConfig;
```

The arguments called don't match the arguments declared.